### PR TITLE
fixed arch PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,16 +7,15 @@ authenticate function given a username, password, and other optional keywords."
 arch=('any')
 url="https://github.com/FirefighterBlu3/python-pam"
 license=('MIT')
-depends=('python','pam')
+depends=('python' 'pam')
+makedepends=('python-setuptools')
 options=(!emptydirs)
-changelog=('ChangeLog')
-source=(https://pypi.python.org/packages/source/p/${pkgname}/${pkgname}-${pkgver}.tar.gz
-        https://pypi.python.org/packages/source/p/${pkgname}/${pkgname}-${pkgver}.tar.gz.asc)
-md5sums=(9a07139fea29e8dae66f5bc37d830a74
-         ee1be19c5a69cb37629bded9a5816335)
+changelog=($srcdir/ChangeLog)
+source=(https://pypi.python.org/packages/source/p/${pkgname}/${pkgname}-${pkgver}.tar.gz)
+md5sums=(db71b6b999246fb05d78ecfbe166629d)
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd "$pkgname-$pkgver"
   python setup.py install --root="$pkgdir/" --optimize=1
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ license=('MIT')
 depends=('python' 'pam')
 makedepends=('python-setuptools')
 options=(!emptydirs)
-changelog=($srcdir/ChangeLog)
+changelog=(ChangeLog)
 source=(https://pypi.python.org/packages/source/p/${pkgname}/${pkgname}-${pkgver}.tar.gz)
 md5sums=(db71b6b999246fb05d78ecfbe166629d)
 


### PR DESCRIPTION
I got this working right. I removed the asc key because it doesn't exist (at least not at that url) and replaced the MD5 sum because it didn't match. Corrected the changelog location. Added python-setuptools as a dependency. Removed improper comma from depends array.

When you get a chance, please submit this to AUR. The python-pam package is orphaned, so you can take over with no issues. I would do it myself, but my only knowledge about this package is I want to build something that depends on it.

Thanks.