### PR TITLE
Verify account availability after initial authentication

### DIFF
--- a/pam.py
+++ b/pam.py
@@ -84,6 +84,10 @@ pam_start                 = libpam.pam_start
 pam_start.restype         = c_int
 pam_start.argtypes        = [c_char_p, c_char_p, POINTER(PamConv), POINTER(PamHandle)]
 
+pam_acct_mgmt             = libpam.pam_acct_mgmt
+pam_acct_mgmt.restype     = c_int
+pam_acct_mgmt.argtypes    = [PamHandle, c_int]
+
 pam_setcred               = libpam.pam_setcred
 pam_setcred.restype       = c_int
 pam_setcred.argtypes      = [PamHandle, c_int]
@@ -175,6 +179,10 @@ class pam():
 
         retval = pam_authenticate(handle, 0)
         auth_success = retval == 0
+
+        if auth_success:
+            retval = pam_acct_mgmt(handle, 0)
+            auth_success = retval == 0
 
         if auth_success and resetcreds:
             retval = pam_setcred(handle, PAM_REINITIALIZE_CRED)

--- a/pam.py
+++ b/pam.py
@@ -177,7 +177,7 @@ class pam():
         auth_success = retval == 0
 
         if auth_success and resetcreds:
-            retval = pam_setcred(handle, PAM_REINITIALIZE_CRED);
+            retval = pam_setcred(handle, PAM_REINITIALIZE_CRED)
 
         # store information to inform the caller why we failed
         self.code   = retval


### PR DESCRIPTION
An user account might be able to authenticate with the given credentials but not being valid (i.e. due to time restraints or expired accounts).
This check is usually performed by calling _pam_acct_mgmt_.

This PR adds this behaviour.
Doing so has been suggested in #8 and #12.