### PR TITLE
Support for multi-factor authentication

### DIFF
--- a/pam.py
+++ b/pam.py
@@ -75,8 +75,8 @@ class pam():
 
         def conv(pam_self, query_list, user_data):
             response = []
-            for prompt, msg in query_list:
-                if msg == PAM.PAM_PROMPT_ECHO_OFF:
+            for index, (prompt, msg) in enumerate(query_list):
+                if msg == PAM.PAM_PROMPT_ECHO_OFF and index == 0:
                     response.append((password, PAM.PAM_SUCCESS))
                 else:
                     response.append((b'', PAM.PAM_SUCCESS))


### PR DESCRIPTION
On systems with multi factor authentication (password and one-time token for example), PAM will ask all the factors in the conversation. Don't duplicate the password, leave the other factors empty instead because OTP systems usually accept the token being appended to the password.

Example PAM dialogue on MFA systems:

```
First Factor:
Second Factor:
```

Without this patch, the provided password would be submitted in both fields, which causes the login process to fail.