### PR TITLE
internals: Root conversation and closure data

### DIFF
--- a/src/pam/__internals.py
+++ b/src/pam/__internals.py
@@ -311,11 +311,11 @@ class PamAuthenticator:
 
         # do this up front so we can safely throw an exception if there's
         # anything wrong with it
-        app_data = {'msgs': self.messages, 'password': password, 'encoding': encoding}
-        conv = PamConv(__conv, c_void_p.from_buffer(py_object(app_data)))
+        self.app_data = {'msgs': self.messages, 'password': password, 'encoding': encoding}
+        self.conv = PamConv(__conv, c_void_p.from_buffer(py_object(self.app_data)))
 
         self.handle = PamHandle()
-        retval = self.pam_start(service, username, byref(conv),
+        retval = self.pam_start(service, username, byref(self.conv),
                                 byref(self.handle))
 
         if retval != PAM_SUCCESS:  # pragma: no cover


### PR DESCRIPTION
If the conversation and closure data are not rooted to the class then they can be garbage collected before the conversation function is invoked.

That leads to a crash in pam_lastlog during session open time.

This commit addressed the issue by assigning the state to the class as properties.