### PR TITLE
{src/pam,pyproject.toml}: Stop using six module. Deprecated.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     'setuptools>=44',
     'wheel>=0.30.0',
-    'six',
 ]
 build-backend = 'setuptools.build_meta'
 
@@ -32,7 +31,6 @@ deps =
     bandit
     flake8
     mypy
-    types-six
     coverage
     pytest-cov
     pytest

--- a/src/pam/__internals.py
+++ b/src/pam/__internals.py
@@ -1,5 +1,4 @@
 import os
-import six
 import sys
 from ctypes import cdll
 from ctypes import CFUNCTYPE
@@ -296,11 +295,11 @@ class PamAuthenticator:
 
             return my_conv(n_messages, messages, p_response, self.libc, msg_list, password, encoding)
 
-        if isinstance(username, six.text_type):
+        if isinstance(username, str):
             username = username.encode(encoding)
-        if isinstance(password, six.text_type):
+        if isinstance(password, str):
             password = password.encode(encoding)
-        if isinstance(service, six.text_type):
+        if isinstance(service, str):
             service = service.encode(encoding)
 
         if b'\x00' in username or b'\x00' in password or b'\x00' in service:
@@ -482,8 +481,7 @@ class PamAuthenticator:
             return PAM_SYSTEM_ERR
 
         #  can't happen unless someone is using internals directly
-        if sys.version_info >= (3, ):  # pragma: no branch
-            if isinstance(key, six.text_type):  # pragma: no branch
+        if isinstance(key, str):  # pragma: no branch
                 key = key.encode(encoding)
 
         value = self.pam_getenv(self.handle, key)

--- a/src/pam/pam.py
+++ b/src/pam/pam.py
@@ -30,7 +30,6 @@ a user against the Pluggable Authentication Modules (PAM) on the system.
 Implemented using ctypes, so no compilation is necessary.
 '''
 
-import six
 import __internals
 
 if __name__ == "__main__":  # pragma: no cover
@@ -43,7 +42,7 @@ if __name__ == "__main__":  # pragma: no cover
             readline.redisplay()
 
         readline.set_pre_input_hook(hook)
-        result = six.moves.input(prompt)  # nosec (bandit; python2)
+        result = input(prompt)  # nosec (bandit; python2)
 
         readline.set_pre_input_hook()
 


### PR DESCRIPTION
See https://bugs.debian.org/1098415 for details.