### PR TITLE
Allow passing mode for CDLL

### DIFF
--- a/src/pam/__internals.py
+++ b/src/pam/__internals.py
@@ -16,6 +16,7 @@ from ctypes import c_int
 from ctypes import c_size_t
 from ctypes import c_void_p
 from ctypes import memmove
+from ctypes import DEFAULT_MODE
 from ctypes.util import find_library
 from typing import Union
 
@@ -176,7 +177,7 @@ class PamAuthenticator:
     code = 0
     reason = None  # type: Union[str, bytes, None]
 
-    def __init__(self):
+    def __init__(self, mode=None):
         # use a trick of dlopen(), this effectively becomes
         # dlopen("", ...) which opens our own executable. since 'python' has
         # a libc dependency, this means libc symbols are already available
@@ -186,7 +187,7 @@ class PamAuthenticator:
         libc = cdll.LoadLibrary(None)
         self.libc = libc
 
-        libpam = CDLL(find_library("pam"))
+        libpam = CDLL(find_library("pam"), mode=mode if mode else DEFAULT_MODE)
         libpam_misc = CDLL(find_library("pam_misc"))
 
         self.handle = None


### PR DESCRIPTION
I noticed that when PAM config includes custom modules, the pam functions invoked by `PamAuthenticator.authenticate` have loading issues (i.e., unable to find custom .so files). This is only fixed when `pam` is loaded in `RTLD_GLOBAL` mode.