### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     'setuptools>=44',
-    'wheel>=0.30.0',
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
 - current version of setuptools (70.1+) does not need wheel at all
 - older versions of setuptools would fetch wheel when building wheels (but not sdists)