### PR TITLE
Fix pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ files = ["src/pam/__init__.py", "src/pam/__internals.py"]
 ignore_missing_imports = true
 
 [tool.pytest]
-python_files = "test_*.py"
-norecursedirs = ".tox"
+python_files = ["test_*.py"]
+norecursedirs = [".tox"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
With recent versions of Python and pytest, this change is required. In my case, I was testing the build with Python 3.14.3 and pytest 9.0.2.