### PR TITLE
**feat** add manual TestPyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,45 @@
+name: Publish to TestPyPI
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: poetry build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary
- Adds a manual `workflow_dispatch` workflow that builds with Poetry and publishes to TestPyPI via OIDC trusted publishing (`testpypi` environment).
- Required so GitHub Actions can list/run the workflow (workflow files must exist on the default branch).

## Test plan
- [ ] Merge this PR
- [ ] Confirm **Publish to TestPyPI** appears under Actions
- [ ] Run workflow, select branch `feature/prepare-for-2.1.0`, approve `testpypi` environment
- [ ] Verify package at https://test.pypi.org/project/python-pam/