### PR TITLE
**docs** add OpenSSF Best Practices badge (13794)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,7 @@ poetry run tox
 
 ## OpenSSF Best Practices
 
-This project aims to earn an
-[OpenSSF Best Practices](https://www.bestpractices.dev/) badge.
-Maintainers: create or update the project entry at
-[bestpractices.dev](https://www.bestpractices.dev/en/projects/new)
-(repo URL: `https://github.com/FirefighterBlu3/python-pam`), then add the
-badge markdown to `README.md` using the assigned project ID.
+This project tracks an
+[OpenSSF Best Practices](https://www.bestpractices.dev/projects/13794) badge
+([project 13794](https://www.bestpractices.dev/projects/13794)).
+Maintainers should keep the entry up to date as practices improve.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # python-pam
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FirefighterBlu3/python-pam/badge)](https://scorecard.dev/viewer/?uri=github.com/FirefighterBlu3/python-pam)
-<!-- After creating the project at https://www.bestpractices.dev/en/projects/new , replace PROJECT_ID and uncomment:
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/PROJECT_ID/badge)](https://www.bestpractices.dev/projects/PROJECT_ID)
--->
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13794/badge)](https://www.bestpractices.dev/projects/13794)
 
 Python pam module supporting py3 for Linux type systems (!windows, !py2)
 


### PR DESCRIPTION
## Summary
- Verified [bestpractices.dev project 13794](https://www.bestpractices.dev/projects/13794) points at this repo (\`in_progress\`, ~31%)
- Add README badge + point CONTRIBUTING at the live entry

## Test plan
- [ ] Badge renders on README
- [ ] Link opens project 13794

Made with [Cursor](https://cursor.com)